### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Fastly MCP brings the power of Fastly's API directly to your AI assistants through the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/@Arodoid/FastlyMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Arodoid/FastlyMCP/badge" alt="FastlyMCP MCP server" />
+</a>
+
 [![](https://badge.mcpx.dev?type=server "MCP Server")](https://modelcontextprotocol.io/introduction)
 [![](https://img.shields.io/badge/Node.js-16+-339933?style=flat-square&logo=node.js&logoColor=white)](https://nodejs.org/)
 [![](https://img.shields.io/badge/License-MIT-red.svg "MIT License")](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
This PR adds a badge for the [FastlyMCP](https://glama.ai/mcp/servers/@Arodoid/FastlyMCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Arodoid/FastlyMCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Arodoid/FastlyMCP/badge" alt="FastlyMCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.